### PR TITLE
OmahaProxy: use endpoint used in official Chromium project

### DIFF
--- a/clients/chrome.py
+++ b/clients/chrome.py
@@ -19,7 +19,7 @@ def getEditions(template):
 	template.stable = True
 	
 	#Looking for releases
-	response = requests.get(url="https://omahaproxy.appspot.com/all.json")
+	response = requests.get(url="https://omahaproxy.appspot.com/json")
 	data = response.json()
 	
 	#Looking releases


### PR DESCRIPTION
Chromium officialy uses `/json` endpoint
https://github.com/chromium/chromium/blob/26d7db41b18fba17766faee123626aaae1b0103d/tools/omahaproxy.py#L21